### PR TITLE
Remove sinatra dependency

### DIFF
--- a/lib/sniffybara.rb
+++ b/lib/sniffybara.rb
@@ -1,26 +1,10 @@
 require "capybara"
 require 'capybara/poltergeist'
 require 'rainbow'
-require 'sinatra/base'
 
 
 module Sniffybara
   class PageNotAccessibleError < StandardError; end
-
-  # Serves the HTMLCS source file to be dynamically loaded into the page
-  class AssetServer < Sinatra::Application
-    PORT = 9006
-    set :port, PORT
-    set :logging, false
-
-    def path_to_htmlcs
-      File.join(File.dirname(File.expand_path(__FILE__)), 'vendor/HTMLCS.js')
-    end
-
-    get '/htmlcs.js' do
-      send_file path_to_htmlcs
-    end
-  end
 
   module NodeOverrides
     def click
@@ -59,11 +43,6 @@ module Sniffybara
       puts Rainbow("\nAll visited screens will be scanned for 508 accessibility compliance.").cyan
 
       Capybara::Poltergeist::Node.prepend(NodeOverrides)
-
-
-      Thread.new do
-        AssetServer.run!    
-      end
     end
 
     def find_accessibility_issues

--- a/lib/sniffybara.rb
+++ b/lib/sniffybara.rb
@@ -70,23 +70,21 @@ module Sniffybara
       execute_script(
         <<-JS
           var htmlcs = document.createElement('script');
-          htmlcs.src = "http://localhost:#{Sniffybara::AssetServer::PORT}/htmlcs.js";
-          htmlcs.async = true;
-          htmlcs.onreadystatechange = htmlcs.onload = function() {
-            window.HTMLCS.process('WCAG2AA', window.document, function() {
-              window.sniffResults = window.HTMLCS.getMessages().map(function(msg) {
-                return {
-                  "type": msg.type,
-                  "code": msg.code,
-                  "msg": msg.msg,
-                  "tagName": msg.element.tagName.toLowerCase(),
-                  "elementId": msg.element.id,
-                  "elementClass": msg.element.className
-                };
-              }) || [];
-            });
-          };
+          htmlcs.innerHTML = #{File.read(File.join(File.dirname(File.expand_path(__FILE__)), 'vendor/HTMLCS.js')).to_json};
           document.querySelector('head').appendChild(htmlcs);
+
+          window.HTMLCS.process('WCAG2AA', window.document, function() {
+            window.sniffResults = window.HTMLCS.getMessages().map(function(msg) {
+              return {
+                "type": msg.type,
+                "code": msg.code,
+                "msg": msg.msg,
+                "tagName": msg.element.tagName.toLowerCase(),
+                "elementId": msg.element.id,
+                "elementClass": msg.element.className
+              };
+            }) || [];
+          });
         JS
       );
 

--- a/lib/sniffybara.rb
+++ b/lib/sniffybara.rb
@@ -45,11 +45,15 @@ module Sniffybara
       Capybara::Poltergeist::Node.prepend(NodeOverrides)
     end
 
+    def htmlcs_source
+      File.read(File.join(File.dirname(File.expand_path(__FILE__)), 'vendor/HTMLCS.js')).to_json
+    end
+
     def find_accessibility_issues
       execute_script(
         <<-JS
           var htmlcs = document.createElement('script');
-          htmlcs.innerHTML = #{File.read(File.join(File.dirname(File.expand_path(__FILE__)), 'vendor/HTMLCS.js')).to_json};
+          htmlcs.innerHTML = #{htmlcs_source};
           document.querySelector('head').appendChild(htmlcs);
 
           window.HTMLCS.process('WCAG2AA', window.document, function() {

--- a/sniffybara.gemspec
+++ b/sniffybara.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |s|
   s.homepage    = ""
   s.license       = ""
 
-  s.add_runtime_dependency "sinatra"
   s.add_runtime_dependency "selenium-webdriver"
   s.add_runtime_dependency "rainbow"
   s.add_runtime_dependency "poltergeist"
 
   s.add_development_dependency "capybara"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "sinatra"
 end


### PR DESCRIPTION
i'm trying to upgrade roadrunner rails (which uses this gem) to rails 5 but that's blocked by sinatra updating its gemspec to use rack 2.0 (which is required by rails 5) https://github.com/sinatra/sinatra/issues/1135

if we don't require sinatra here then that'll fix the problem

