### PR TITLE
Update click method to support latest Capybara

### DIFF
--- a/lib/sniffybara.rb
+++ b/lib/sniffybara.rb
@@ -5,7 +5,7 @@ module Sniffybara
   class PageNotAccessibleError < StandardError; end
 
   module NodeOverrides
-    def click
+    def click(*keys, wait: nil, **offset)
       super
       Sniffybara::Driver.current_driver.process_accessibility_issues
     end


### PR DESCRIPTION
**Why**: We want to update the caseflow repo to use the latest version
of Capybara (3.x), which now expects arguments for the `click` method.